### PR TITLE
replace Promise with (Promise Any) due to kinding

### DIFF
--- a/private/pure-function.rkt
+++ b/private/pure-function.rkt
@@ -30,8 +30,8 @@
 
 (unsafe-require/typed
  "pure-unsafe.rkt"
- [promise/pure/maybe-stateful? (→ Any Boolean : Promise)]
- [promise/pure/stateless? (→ Any Boolean : Promise)]
+ [promise/pure/maybe-stateful? (→ Any Boolean : (Promise Any))]
+ [promise/pure/stateless? (→ Any Boolean : (Promise Any))]
  [make-promise/pure/stateful (∀ (a) (→ (→ a) (Promise a)))]
  [make-promise/pure/stateless (∀ (a) (→ (→ a) (Promise a)))]
  [declared-stateful-pure-function? (→ Any Boolean)]


### PR DESCRIPTION
`Promise` is now a type constructor.

related to https://github.com/racket/typed-racket/pull/1143